### PR TITLE
fix: CORS設定にAzureフロントエンドURLを追加

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:3000",
+        "https://tech0-gen-11-step3-2-node-67.azurewebsites.net",
     ],
     allow_credentials=True,
     allow_methods=["GET", "POST", "PATCH", "DELETE"],


### PR DESCRIPTION
Google OAuth認証がAzure環境で動作するよう、
allow_originsにデプロイ先URL（https://tech0-gen-11-step3-2-node-67.azurewebsites.net）を追加