### PR TITLE
  [Issue #56] 本番環境で支出保存が502エラーになるバグを修正

### DIFF
--- a/frontend/app/api/expenses/route.ts
+++ b/frontend/app/api/expenses/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 // バックエンド側の実装差を吸収するために候補を複数持つ
 const CANDIDATE_PATHS = ["/expenses", "/api/expenses"];
@@ -83,7 +83,7 @@ export async function POST(req: NextRequest) {
   // 2) ここまで来たら「バックエンド未起動 or どのパスも無い」
   // 開発中はモックで成功させてUI実装を先に完了させる
   if (process.env.NODE_ENV !== "production") {
-    let payload: any = {};
+    let payload: Record<string, unknown> = {};
     try {
       payload = await req.json();
     } catch {}


### PR DESCRIPTION
説明:                                                                                                                    
  ## 実装内容                                                                                                              
  - `frontend/app/api/expenses/route.ts` の環境変数 `BACKEND_URL`（未定義）を `NEXT_PUBLIC_API_URL` に修正                 
  - 本番環境で expenses の Route Handler だけが `localhost:8000` にリクエストを送っていたため、502エラーが発生していた     
                                                                                                                           
  ## 関連Issue
  Closes #56

  ## 動作確認
  - [ ] 本番環境で手入力から支出を保存できること
  - [ ] 内訳モーダルに登録したデータが反映されること