### PR TITLE
fix: #82 #83 AIコーチ仕様改善・手入力保存後の即時反映

### DIFF
--- a/frontend/app/_components/AICoachModal.tsx
+++ b/frontend/app/_components/AICoachModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import ReactMarkdown from 'react-markdown';
 import { X } from 'lucide-react';
@@ -16,6 +16,13 @@ type Props = {
 export function AICoachModal({ open, onClose, coachMode }: Props) {
   const [aiAnalysis, setAiAnalysis] = useState<string | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
+
+  // モーダルを開くたびに前回の分析結果をリセット
+  useEffect(() => {
+    if (open) {
+      setAiAnalysis(null);
+    }
+  }, [open]);
 
   const handleStartAnalysis = async () => {
     setIsAnalyzing(true);
@@ -57,7 +64,7 @@ export function AICoachModal({ open, onClose, coachMode }: Props) {
           <h3 className="font-bold text-[16px] text-[#2a3449]">今月の分析</h3>
           {aiAnalysis ? (
             <>
-              <div className="bg-[#f7f6f5] rounded-[16px] px-[16px] py-[20px] max-h-[400px] overflow-y-auto prose prose-sm max-w-none">
+              <div className="bg-[#f7f6f5] rounded-[16px] px-[20px] py-[20px] overflow-y-auto prose max-w-none prose-headings:text-[#2a3449] prose-headings:text-[15px] prose-headings:mt-[16px] prose-headings:mb-[8px] prose-p:text-[14px] prose-p:leading-[1.8] prose-p:text-[#3a3a3a] prose-p:my-[8px] prose-li:text-[14px] prose-li:leading-[1.8] prose-li:text-[#3a3a3a] prose-li:my-[4px] prose-strong:text-[#2a3449] prose-ul:my-[8px] prose-ol:my-[8px]">
                 <ReactMarkdown>
                   {aiAnalysis}
                 </ReactMarkdown>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useAuth } from '@/lib/contexts/AuthContext';
@@ -32,13 +32,17 @@ export default function HomePage() {
     }
   }, [isLoading, user, router]);
 
-  useEffect(() => {
+  const fetchAnalyze = useCallback(() => {
     if (user?.nickname) {
       get<AnalyzeResponse>(`/api/analyze`)
         .then(setData)
         .catch(console.error);
     }
   }, [user]);
+
+  useEffect(() => {
+    fetchAnalyze();
+  }, [fetchAnalyze]);
 
   if (isLoading) {
     return (
@@ -228,18 +232,17 @@ export default function HomePage() {
         open={isBudgetOpen}
         onClose={() => setIsBudgetOpen(false)}
         currentBudget={data.budget}
-        onSuccess={() => {
-          get<AnalyzeResponse>('/api/analyze')
-            .then(setData)
-            .catch(console.error);
-        }}
+        onSuccess={fetchAnalyze}
       />
 
       {/* ★ 手入力モーダル（内訳モーダルより上に表示されるよう z-[70]） */}
       <ExpenseInputModal
         open={isInputOpen}
         onClose={() => setIsInputOpen(false)}
-        onSuccess={() => setHistoryRefreshKey(k => k + 1)}
+        onSuccess={() => {
+          setHistoryRefreshKey(k => k + 1);
+          fetchAnalyze();
+        }}
       />
 
       {/* フローティングボタン*/}


### PR DESCRIPTION
Close #82 
Close #83 

分析テキストの見やすさ改善だけ、
イシューになかったけど勝手に追加で修正してます！

# 今回の修正まとめ

## Issue #83: 手入力保存後のホーム画面即時反映
**対象:** `page.tsx`

- データ取得ロジックを `fetchAnalyze` 関数に切り出し
- 手入力モーダルの `onSuccess` で `fetchAnalyze()` を呼び出すように変更
- **結果:** 支出を手入力で保存すると、ページ更新なしで消費・残金が即座に反映される

---

## Issue #82: AIコーチの仕様改善

### 1. アドバイスの質を向上
**対象:** `analyze.py`

- AIプロンプトにカテゴリ別支出集計と今月の全支出履歴を追加
- 「金額だけ」→「何にいくら使ったか」をAIが把握した上でアドバイス生成

### 2. 古いデータ表示の解消
**対象:** `AICoachModal.tsx`

- モーダルを開くたびに前回の分析結果をリセット（`useEffect` で `open` を監視）
- **結果:** 予算設定後に再度開くと「分析開始ボタンを押してください」の初期状態に戻り、最新データで分析できる

### 3. 分析テキストの見やすさ改善
**対象:** `AICoachModal.tsx`

- 高さ制限（`max-h-[400px]`）を撤廃し、モーダル全体でスクロール
- フォントサイズ・行間・余白を調整して読みやすく
