### PR TITLE
fix: coachModeの型エラーを修正（string → 'angel' | 'demon'）

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -178,7 +178,7 @@ export default function DashboardPage() {
       <AICoachModal 
         open={isAIModalOpen} 
         onClose={() => setIsAIModalOpen(false)} 
-        coachMode={(user?.coach_mode === 'devil' ? 'demon' : user?.coach_mode) || 'demon'}
+        coachMode={((user?.coach_mode === 'devil' ? 'demon' : user?.coach_mode) || 'demon') as 'angel' | 'demon'}
       />
 
       {/* 浮遊アクションボタン (FAB): 支出登録ショートカット */}


### PR DESCRIPTION
## coachMode 型エラー修正

このプルリクエストをマージ後にデプロイエラー起こったので下記修正
https://github.com/Shun0914/project_class4/pull/78

### エラー内容
`frontend/app/dashboard/page.tsx:181` で TypeScript ビルドエラーが発生し、デプロイが失敗。

Type error: Type 'string' is not assignable to type '"angel" | "demon"'.



### 原因
`AICoachModal` の `coachMode` プロパティは `'angel' | 'demon'` のみ受け付けるが、`user?.coach_mode`（`string` 型）をキャストせずに渡していた。

### 修正内容
```tsx
// 修正前
coachMode={(user?.coach_mode === 'devil' ? 'demon' : user?.coach_mode) || 'demon'}

// 修正後
coachMode={((user?.coach_mode === 'devil' ? 'demon' : user?.coach_mode) || 'demon') as 'angel' | 'demon'}

参考
ホーム画面（page.tsx:220）では as 'angel' | 'demon' でキャスト済みだったため同様のエラーは発生していなかった。


